### PR TITLE
fixing docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   w3bapp:
-    image: ${WS_BACKEND_IMAGE:-ghcr.io/machinefi/w3bstream:latest}
+    image: ${WS_BACKEND_IMAGE:-ghcr.io/machinefi/w3bstream:v1.5.9}
     depends_on:
       - 'postgres'
       - 'mqtt_server'
@@ -27,7 +27,7 @@ services:
       SRV_APPLET_MGR__MonitorDB_Master: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432/${POSTGRES_DB:-w3bstream}?sslmode=disable&application_name=monitor
       SRV_APPLET_MGR__MonitorDB_ConnMaxLifetime: 10m
       SRV_APPLET_MGR__MonitorDB_PoolSize: 5
-      SRV_APPLET_MGR__WasmDB: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432
+      SRV_APPLET_MGR__WasmDBConfig_Endpoint: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432
       SRV_APPLET_MGR__MqttBroker_Server: mqtt://mqtt_server:1883
       SRV_APPLET_MGR__MetricsCenter_Endpoint: http://prometheus:9090
       SRV_APPLET_MGR__MetricsCenter_ClickHouseDSN: ''
@@ -38,7 +38,7 @@ services:
       - ${WS_WORKING_DIR:-.}/asserts:/w3bstream/asserts
 
   w3bstream-studio:
-    image: ${WS_STUDIO_IMAGE:-ghcr.io/machinefi/w3bstream-studio:main}
+    image: ${WS_STUDIO_IMAGE:-ghcr.io/machinefi/w3bstream-studio:v1.5.9}
     container_name: w3bstream-studio
     restart: always
     platform: linux/x86_64

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       SRV_APPLET_MGR__Postgres_Master: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432/${POSTGRES_DB:-w3bstream}?sslmode=disable&application_name=mgr
       SRV_APPLET_MGR__Postgres_ConnMaxLifetime: 10m
       SRV_APPLET_MGR__Postgres_PoolSize: 5
+      SRV_APPLET_MGR__Redis_Host: redis
+      SRV_APPLET_MGR__Redis_Password: 'w3bredispasS'
       SRV_APPLET_MGR__MonitorDB_Master: postgresql://${POSTGRES_USER:-w3badmin}:${POSTGRES_PASSWORD:-PaSsW0Rd}@postgres:5432/${POSTGRES_DB:-w3bstream}?sslmode=disable&application_name=monitor
       SRV_APPLET_MGR__MonitorDB_ConnMaxLifetime: 10m
       SRV_APPLET_MGR__MonitorDB_PoolSize: 5
@@ -89,6 +91,19 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD:-w3bredispasS}
     ports:
       - '6379:6379'
+
+  prometheus:
+    image: prom/prometheus:latest
+    depends_on:
+      - 'w3bapp'
+    user: root
+    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+    container_name: prometheus
+    restart: always
+    volumes:
+      - ${WS_WORKING_DIR:-.}/prometheus:/data
+    ports:
+      - '9090:9090'
 
 volumes:
   mqtt:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
     container_name: prometheus
     restart: always
     volumes:
-      - ${WS_WORKING_DIR:-.}/prometheus:/data
+      - prometheus:/data
     ports:
       - '9090:9090'
 
@@ -110,3 +110,4 @@ volumes:
   postgres:
   w3bstream_assets:
   redis:
+  prometheus:


### PR DESCRIPTION
This fixes the w3bstream docker-compose file, and uses the latest 1.5.9 images, as the main and latest tags for w3bstream and w3bstream-studio haven't been updated in a long time